### PR TITLE
use fake vignette to keep CRAN/R CMD build happy

### DIFF
--- a/inst/doc/vignette_source/RedisAPI.Rmd
+++ b/inst/doc/vignette_source/RedisAPI.Rmd
@@ -1,0 +1,245 @@
+---
+title: "Using Redis with RedisAPI"
+author: "Rich FitzJohn"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Using Redis with RedisAPI}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
+---
+
+``` {r }
+library(RedisAPI)
+```
+
+``` {r echo=FALSE,results="hide"}
+library(RcppRedis)
+RedisAPI::hiredis()$DEL(c("mykey", "mylist", "mylist2"))
+```
+
+The main feature of `RedisAPI` is to provide a full interface to
+the Redis API.  It provdes access to `r length(grep("^[A-Z]",
+names(RedisAPI:::redis_api_generator$public_methods)))` Redis
+commands s a set of user-friendly R functions that do basic error
+checking.  This is the level that new applications would be build
+from, and `rdb` is built on top of a *driver*, which allows use
+with [`RcppRedis`](https://github.com/eddelbuettel/rcppredis),
+[`rredis`](http://cran.r-project.org/web/packages/rredis/index.html)
+and [`rrlite`](https://github.com/ropensci/rrlite).
+
+It is possible to build friendly applications on top of this, for
+example, the built in `rdb` R key-value store and
+[`storr`](https://github.com/richfitz/storr) which provides a
+content-addressable object store, and
+[`rrqueue`](https://github.com/richfitz/rrqueue) which implements a
+scalable queuing system.
+
+# Redis API
+
+This gives you all the power of Redis, but you will have to
+manually serialise/deserialise all complicated R objects.
+
+``` {r }
+r <- RedisAPI::hiredis()
+```
+
+The `redis_api` object is an [`R6`](https://github.com/wch/R6)
+class with many methods, corresponding to different Redis commands.
+For example, `SET` and `GET`:
+
+``` {r }
+r$SET("mykey", "mydata") # set the key "mykey" to the value "mydata"
+r$GET("mykey")
+```
+
+The value must be a string or will be coerced into one.  So if you
+want to save an arbitrary R object, you need to convert it to a
+string.  The `object_to_string` function and its inverse
+`string_to_object` can help here:
+
+``` {r }
+s <- object_to_string(1:10)
+s # ew. but this does encode everything about this object
+string_to_object(s) # here's the original back
+```
+
+So:
+``` {r }
+r$SET("mylist", object_to_string(1:10))
+r$GET("mylist")
+string_to_object(r$GET("mylist"))
+```
+
+This is how the `rdb` object is implemented!
+
+However, Redis offers far better ways of holding lists, if that is the aim:
+
+``` {r }
+r$RPUSH("mylist2", 1:10)
+```
+
+(the returned value `10` indicates that the list "mylist2" is 10
+elements long).  There are [lots of
+commands](http://redis.io/commands/#list) for operating on lits,
+but you can do things like
+
+* get an element by its index (note tht this uses C-style base0
+indexing for consistency with the `Redis` documentation rather than
+R's semantics)
+``` {r }
+r$LINDEX("mylist2", 1)
+```
+
+* set an element by its index
+``` {r }
+r$LSET("mylist2", 1, "carrot")
+```
+
+* get all of a list:
+``` {r }
+r$LRANGE("mylist2", 0, -1)
+```
+
+* or part of it:
+``` {r }
+r$LRANGE("mylist2", 0, 2)
+```
+
+* pop elements off the front or back
+``` {r }
+r$LLEN("mylist2")
+r$LPOP("mylist2")
+r$RPOP("mylist2")
+r$LLEN("mylist2")
+```
+
+Of course, each element of the list can be an R object if you run
+it through `object_to_string`:
+
+``` {r }
+r$LPUSH("mylist2", object_to_string(1:10))
+```
+
+but you'll be responsible for converting that back (and detecting
+/ knowing that this needs doing)
+
+``` {r }
+dat <- r$LRANGE("mylist2", 0, 2)
+dat
+dat[[1]] <- string_to_object(dat[[1]])
+dat
+```
+
+# High level (`rdb`)
+
+Create a new database in memory (this is not written to disk, and
+I've not actually worked out how to save to disk once the database
+is created...)
+``` {r }
+db <- rdb(hiredis)
+```
+
+Newly created databases are empty - they have no keys
+``` {r }
+db$keys()
+```
+
+R objects can be stored against keys, for example:
+``` {r }
+db$set("mykey", 1:10)
+db$keys()
+```
+
+Retrieve the value of a key with `$get`:
+``` {r }
+db$get("mykey")
+```
+
+Trying to get a nonexistant key does not throw an error but returns
+`NULL`
+``` {r }
+db$get("no_such_key")
+```
+
+That's it.  Arbitrary R objects can be stored in keys, and they
+will be returned intact with few exceptions (the exceptions are
+things like `rdb` itself which includes an "external pointer"
+object which can't be serialised - see `?serialize` for more
+information):
+``` {r }
+db$set("mtcars", mtcars)
+identical(db$get("mtcars"), mtcars)
+db$set("a_function", sin)
+db$get("a_function")(pi / 2) # 1
+```
+
+This seems really silly, but is potentially very useful.  There are
+file-based key/value systems on CRAN, and this would be another but
+backed by a potentailly very efficient store (and without the
+overhead of disk access).
+
+# Potential applications
+
+Because `RedisAPI` exposes all of Redis, you can roll your own data
+structures.
+
+First, a generator object that sets up a new list at `key` within
+the database `r`.
+``` {r }
+rlist <- function(..., key=NULL, r=RedisAPI::hiredis()) {
+  if (is.null(key)) {
+    key <- paste(sample(letters, 32, replace=TRUE), collapse="")
+  }
+  dat <- vapply(c(...), object_to_string, character(1))
+  r$RPUSH(key, dat)
+  ret <- list(r=r, key=key)
+  class(ret) <- "rlist"
+  ret
+}
+```
+
+Then some S3 methods that work with this object.  I've only
+implemented `length` and `[[`, but `[` would be useful here too as
+would `print`.
+``` {r }
+length.rlist <- function(x) {
+  x$r$LLEN(x$key)
+}
+
+`[[.rlist` <- function(x, i, ...) {
+  string_to_object(x$r$LINDEX(x$key, i - 1L))
+}
+
+`[[<-.rlist` <- function(x, i, value, ...) {
+  x$r$LSET(x$key, i - 1L, object_to_string(value))
+  x
+}
+```
+
+Then we have this weird object we can add things to.
+``` {r }
+obj <- rlist(1:10)
+length(obj) # 10
+obj[[3]]
+obj[[3]] <- "an element"
+obj[[3]]
+```
+
+The object has reference semantics so that assignment does *not* make a copy:
+``` {r }
+obj2 <- obj
+obj2[[2]] <- obj2[[2]] * 2
+obj[[2]] == obj2[[2]]
+```
+
+What would be nice is a set of tools for working with any R/`Redis`
+package that can convert R objects into `Redis` data structures so
+that they can be accessed in pieces even if they are far too big to
+fit into memory.  Of course, these objects could be read/written by
+programs *other* than R if they also support `Redis`.
+
+``` {r }
+# cleanup:
+r$DEL(c("mykey", "mylist", "mylist2"))
+```

--- a/inst/doc/vignette_source/make_fake_vignette.R
+++ b/inst/doc/vignette_source/make_fake_vignette.R
@@ -1,0 +1,6 @@
+# Knit to execute all the R code and replace with appropriate markdown chunks
+# We don't use render because we want the yaml intact, and we want syntax highlighting
+knitr::knit("RedisAPI.Rmd")
+
+## Move the output .md to vignettes as if it were an .Rmd source
+file.copy("RedisAPI.md", "../../../vignettes/RedisAPI.Rmd")

--- a/vignettes/RedisAPI.Rmd
+++ b/vignettes/RedisAPI.Rmd
@@ -1,32 +1,13 @@
----
-title: "Using Redis with RedisAPI"
-author: "Rich FitzJohn"
-date: "`r Sys.Date()`"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Using Redis with RedisAPI}
-  %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
----
+    library(RedisAPI)
 
-``` {r }
-library(RedisAPI)
-```
-
-``` {r echo=FALSE,results="hide"}
-library(RcppRedis)
-RedisAPI::hiredis()$DEL(c("mykey", "mylist", "mylist2"))
-```
-
-The main feature of `RedisAPI` is to provide a full interface to
-the Redis API.  It provdes access to `r length(grep("^[A-Z]",
-names(RedisAPI:::redis_api_generator$public_methods)))` Redis
-commands s a set of user-friendly R functions that do basic error
-checking.  This is the level that new applications would be build
-from, and `rdb` is built on top of a *driver*, which allows use
-with [`RcppRedis`](https://github.com/eddelbuettel/rcppredis),
-[`rredis`](http://cran.r-project.org/web/packages/rredis/index.html)
-and [`rrlite`](https://github.com/ropensci/rrlite).
+The main feature of `RedisAPI` is to provide a full interface to the
+Redis API. It provdes access to 149 Redis commands s a set of
+user-friendly R functions that do basic error checking. This is the
+level that new applications would be build from, and `rdb` is built on
+top of a *driver*, which allows use with
+[`RcppRedis`](https://github.com/eddelbuettel/rcppredis),
+[`rredis`](http://cran.r-project.org/web/packages/rredis/index.html) and
+[`rrlite`](https://github.com/ropensci/rrlite).
 
 It is possible to build friendly applications on top of this, for
 example, the built in `rdb` R key-value store and
@@ -35,211 +16,314 @@ content-addressable object store, and
 [`rrqueue`](https://github.com/richfitz/rrqueue) which implements a
 scalable queuing system.
 
-# Redis API
+Redis API
+=========
 
-This gives you all the power of Redis, but you will have to
-manually serialise/deserialise all complicated R objects.
+This gives you all the power of Redis, but you will have to manually
+serialise/deserialise all complicated R objects.
 
-``` {r }
-r <- RedisAPI::hiredis()
-```
+    r <- RedisAPI::hiredis()
 
-The `redis_api` object is an [`R6`](https://github.com/wch/R6)
-class with many methods, corresponding to different Redis commands.
-For example, `SET` and `GET`:
+The `redis_api` object is an [`R6`](https://github.com/wch/R6) class
+with many methods, corresponding to different Redis commands. For
+example, `SET` and `GET`:
 
-``` {r }
-r$SET("mykey", "mydata") # set the key "mykey" to the value "mydata"
-r$GET("mykey")
-```
+    r$SET("mykey", "mydata") # set the key "mykey" to the value "mydata"
 
-The value must be a string or will be coerced into one.  So if you
-want to save an arbitrary R object, you need to convert it to a
-string.  The `object_to_string` function and its inverse
-`string_to_object` can help here:
+    ## [1] "OK"
 
-``` {r }
-s <- object_to_string(1:10)
-s # ew. but this does encode everything about this object
-string_to_object(s) # here's the original back
-```
+    r$GET("mykey")
+
+    ## [1] "mydata"
+
+The value must be a string or will be coerced into one. So if you want
+to save an arbitrary R object, you need to convert it to a string. The
+`object_to_string` function and its inverse `string_to_object` can help
+here:
+
+    s <- object_to_string(1:10)
+    s # ew. but this does encode everything about this object
+
+    ## [1] "A\n2\n197121\n131840\n13\n10\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+
+    string_to_object(s) # here's the original back
+
+    ##  [1]  1  2  3  4  5  6  7  8  9 10
 
 So:
-``` {r }
-r$SET("mylist", object_to_string(1:10))
-r$GET("mylist")
-string_to_object(r$GET("mylist"))
-```
+
+    r$SET("mylist", object_to_string(1:10))
+
+    ## [1] "OK"
+
+    r$GET("mylist")
+
+    ## [1] "A\n2\n197121\n131840\n13\n10\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+
+    string_to_object(r$GET("mylist"))
+
+    ##  [1]  1  2  3  4  5  6  7  8  9 10
 
 This is how the `rdb` object is implemented!
 
-However, Redis offers far better ways of holding lists, if that is the aim:
+However, Redis offers far better ways of holding lists, if that is the
+aim:
 
-``` {r }
-r$RPUSH("mylist2", 1:10)
-```
+    r$RPUSH("mylist2", 1:10)
+
+    ## [1] 10
 
 (the returned value `10` indicates that the list "mylist2" is 10
-elements long).  There are [lots of
-commands](http://redis.io/commands/#list) for operating on lits,
-but you can do things like
+elements long). There are [lots of
+commands](http://redis.io/commands/#list) for operating on lits, but you
+can do things like
 
-* get an element by its index (note tht this uses C-style base0
-indexing for consistency with the `Redis` documentation rather than
-R's semantics)
-``` {r }
-r$LINDEX("mylist2", 1)
-```
+-   get an element by its index (note tht this uses C-style base0
+    indexing for consistency with the `Redis` documentation rather than
+    R's semantics)
 
-* set an element by its index
-``` {r }
-r$LSET("mylist2", 1, "carrot")
-```
+<!-- -->
 
-* get all of a list:
-``` {r }
-r$LRANGE("mylist2", 0, -1)
-```
+    r$LINDEX("mylist2", 1)
 
-* or part of it:
-``` {r }
-r$LRANGE("mylist2", 0, 2)
-```
+    ## [1] "2"
 
-* pop elements off the front or back
-``` {r }
-r$LLEN("mylist2")
-r$LPOP("mylist2")
-r$RPOP("mylist2")
-r$LLEN("mylist2")
-```
+-   set an element by its index
 
-Of course, each element of the list can be an R object if you run
-it through `object_to_string`:
+<!-- -->
 
-``` {r }
-r$LPUSH("mylist2", object_to_string(1:10))
-```
+    r$LSET("mylist2", 1, "carrot")
 
-but you'll be responsible for converting that back (and detecting
-/ knowing that this needs doing)
+    ## [1] "OK"
 
-``` {r }
-dat <- r$LRANGE("mylist2", 0, 2)
-dat
-dat[[1]] <- string_to_object(dat[[1]])
-dat
-```
+-   get all of a list:
 
-# High level (`rdb`)
+<!-- -->
 
-Create a new database in memory (this is not written to disk, and
-I've not actually worked out how to save to disk once the database
-is created...)
-``` {r }
-db <- rdb(hiredis)
-```
+    r$LRANGE("mylist2", 0, -1)
+
+    ## [[1]]
+    ## [1] "1"
+    ## 
+    ## [[2]]
+    ## [1] "carrot"
+    ## 
+    ## [[3]]
+    ## [1] "3"
+    ## 
+    ## [[4]]
+    ## [1] "4"
+    ## 
+    ## [[5]]
+    ## [1] "5"
+    ## 
+    ## [[6]]
+    ## [1] "6"
+    ## 
+    ## [[7]]
+    ## [1] "7"
+    ## 
+    ## [[8]]
+    ## [1] "8"
+    ## 
+    ## [[9]]
+    ## [1] "9"
+    ## 
+    ## [[10]]
+    ## [1] "10"
+
+-   or part of it:
+
+<!-- -->
+
+    r$LRANGE("mylist2", 0, 2)
+
+    ## [[1]]
+    ## [1] "1"
+    ## 
+    ## [[2]]
+    ## [1] "carrot"
+    ## 
+    ## [[3]]
+    ## [1] "3"
+
+-   pop elements off the front or back
+
+<!-- -->
+
+    r$LLEN("mylist2")
+
+    ## [1] 10
+
+    r$LPOP("mylist2")
+
+    ## [1] "1"
+
+    r$RPOP("mylist2")
+
+    ## [1] "10"
+
+    r$LLEN("mylist2")
+
+    ## [1] 8
+
+Of course, each element of the list can be an R object if you run it
+through `object_to_string`:
+
+    r$LPUSH("mylist2", object_to_string(1:10))
+
+    ## [1] 9
+
+but you'll be responsible for converting that back (and detecting /
+knowing that this needs doing)
+
+    dat <- r$LRANGE("mylist2", 0, 2)
+    dat
+
+    ## [[1]]
+    ## [1] "A\n2\n197121\n131840\n13\n10\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+    ## 
+    ## [[2]]
+    ## [1] "carrot"
+    ## 
+    ## [[3]]
+    ## [1] "3"
+
+    dat[[1]] <- string_to_object(dat[[1]])
+    dat
+
+    ## [[1]]
+    ##  [1]  1  2  3  4  5  6  7  8  9 10
+    ## 
+    ## [[2]]
+    ## [1] "carrot"
+    ## 
+    ## [[3]]
+    ## [1] "3"
+
+High level (`rdb`)
+==================
+
+Create a new database in memory (this is not written to disk, and I've
+not actually worked out how to save to disk once the database is
+created...)
+
+    db <- rdb(hiredis)
 
 Newly created databases are empty - they have no keys
-``` {r }
-db$keys()
-```
+
+    db$keys()
+
+    ## [1] "mykey"      "a_function" "mtcars"
 
 R objects can be stored against keys, for example:
-``` {r }
-db$set("mykey", 1:10)
-db$keys()
-```
+
+    db$set("mykey", 1:10)
+    db$keys()
+
+    ## [1] "mykey"      "a_function" "mtcars"
 
 Retrieve the value of a key with `$get`:
-``` {r }
-db$get("mykey")
-```
+
+    db$get("mykey")
+
+    ##  [1]  1  2  3  4  5  6  7  8  9 10
 
 Trying to get a nonexistant key does not throw an error but returns
 `NULL`
-``` {r }
-db$get("no_such_key")
-```
 
-That's it.  Arbitrary R objects can be stored in keys, and they
-will be returned intact with few exceptions (the exceptions are
-things like `rdb` itself which includes an "external pointer"
-object which can't be serialised - see `?serialize` for more
-information):
-``` {r }
-db$set("mtcars", mtcars)
-identical(db$get("mtcars"), mtcars)
-db$set("a_function", sin)
-db$get("a_function")(pi / 2) # 1
-```
+    db$get("no_such_key")
 
-This seems really silly, but is potentially very useful.  There are
+    ## NULL
+
+That's it. Arbitrary R objects can be stored in keys, and they will be
+returned intact with few exceptions (the exceptions are things like
+`rdb` itself which includes an "external pointer" object which can't be
+serialised - see `?serialize` for more information):
+
+    db$set("mtcars", mtcars)
+    identical(db$get("mtcars"), mtcars)
+
+    ## [1] TRUE
+
+    db$set("a_function", sin)
+    db$get("a_function")(pi / 2) # 1
+
+    ## [1] 1
+
+This seems really silly, but is potentially very useful. There are
 file-based key/value systems on CRAN, and this would be another but
-backed by a potentailly very efficient store (and without the
-overhead of disk access).
+backed by a potentailly very efficient store (and without the overhead
+of disk access).
 
-# Potential applications
+Potential applications
+======================
 
 Because `RedisAPI` exposes all of Redis, you can roll your own data
 structures.
 
-First, a generator object that sets up a new list at `key` within
-the database `r`.
-``` {r }
-rlist <- function(..., key=NULL, r=RedisAPI::hiredis()) {
-  if (is.null(key)) {
-    key <- paste(sample(letters, 32, replace=TRUE), collapse="")
-  }
-  dat <- vapply(c(...), object_to_string, character(1))
-  r$RPUSH(key, dat)
-  ret <- list(r=r, key=key)
-  class(ret) <- "rlist"
-  ret
-}
-```
+First, a generator object that sets up a new list at `key` within the
+database `r`.
 
-Then some S3 methods that work with this object.  I've only
-implemented `length` and `[[`, but `[` would be useful here too as
-would `print`.
-``` {r }
-length.rlist <- function(x) {
-  x$r$LLEN(x$key)
-}
+    rlist <- function(..., key=NULL, r=RedisAPI::hiredis()) {
+      if (is.null(key)) {
+        key <- paste(sample(letters, 32, replace=TRUE), collapse="")
+      }
+      dat <- vapply(c(...), object_to_string, character(1))
+      r$RPUSH(key, dat)
+      ret <- list(r=r, key=key)
+      class(ret) <- "rlist"
+      ret
+    }
 
-`[[.rlist` <- function(x, i, ...) {
-  string_to_object(x$r$LINDEX(x$key, i - 1L))
-}
+Then some S3 methods that work with this object. I've only implemented
+`length` and `[[`, but `[` would be useful here too as would `print`.
 
-`[[<-.rlist` <- function(x, i, value, ...) {
-  x$r$LSET(x$key, i - 1L, object_to_string(value))
-  x
-}
-```
+    length.rlist <- function(x) {
+      x$r$LLEN(x$key)
+    }
+
+    `[[.rlist` <- function(x, i, ...) {
+      string_to_object(x$r$LINDEX(x$key, i - 1L))
+    }
+
+    `[[<-.rlist` <- function(x, i, value, ...) {
+      x$r$LSET(x$key, i - 1L, object_to_string(value))
+      x
+    }
 
 Then we have this weird object we can add things to.
-``` {r }
-obj <- rlist(1:10)
-length(obj) # 10
-obj[[3]]
-obj[[3]] <- "an element"
-obj[[3]]
-```
 
-The object has reference semantics so that assignment does *not* make a copy:
-``` {r }
-obj2 <- obj
-obj2[[2]] <- obj2[[2]] * 2
-obj[[2]] == obj2[[2]]
-```
+    obj <- rlist(1:10)
+    length(obj) # 10
+
+    ## [1] 10
+
+    obj[[3]]
+
+    ## [1] 3
+
+    obj[[3]] <- "an element"
+    obj[[3]]
+
+    ## [1] "an element"
+
+The object has reference semantics so that assignment does *not* make a
+copy:
+
+    obj2 <- obj
+    obj2[[2]] <- obj2[[2]] * 2
+    obj[[2]] == obj2[[2]]
+
+    ## [1] TRUE
 
 What would be nice is a set of tools for working with any R/`Redis`
-package that can convert R objects into `Redis` data structures so
-that they can be accessed in pieces even if they are far too big to
-fit into memory.  Of course, these objects could be read/written by
-programs *other* than R if they also support `Redis`.
+package that can convert R objects into `Redis` data structures so that
+they can be accessed in pieces even if they are far too big to fit into
+memory. Of course, these objects could be read/written by programs
+*other* than R if they also support `Redis`.
 
-``` {r }
-# cleanup:
-r$DEL(c("mykey", "mylist", "mylist2"))
-```
+    # cleanup:
+    r$DEL(c("mykey", "mylist", "mylist2"))
+
+    ## [1] 3


### PR DESCRIPTION
Here's the skinny:
- I just moved your `.Rmd` vignette to `inst/doc/vignette_source` directory
- In that directory, I also added `make_fake_vignette.R`.  Running that script from the `vignette_source` directory will just knit the vignette and copy the output into `vignettes/`

R now thinks you have a vignette with no actual R code, and just compiles the `.Rmd` into `html` that looks identical to what it did previously.  This way you don't need `--no-build-vignettes` so users will still have access to a local vignette copy and CRAN should be happy.  (This is the old-school hack that I think @eddelbuettel suggested on slack)

Unfortunately, this obviously means that nothing is tested either.  I'd suggest modifying your `.travis.yml` to knit the true vignette explicitly, since you have a redis-server running there.  That way travis at least will cover your ass on tests; but I didn't do that step here. 

Sound okay?
